### PR TITLE
Expand tests

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,5 +22,8 @@
     "purescript-globals": "~0.2.1",
     "purescript-maps": "~0.5.2",
     "purescript-nullable": "~0.2.1"
+  },
+  "devDependencies": {
+    "purescript-assert": "~0.1.1"
   }
 }


### PR DESCRIPTION
Add more tests which roundtrip various types using their `Generic` instances.

These all pass apart from `TupleArray`, which, as far as I can tell, is a bug in this library (or perhaps in generic deriving). I tried to track it down but I haven't been very successful.