### PR TITLE
Encode/Decode instances for StrMap

### DIFF
--- a/src/Data/Foreign/Class.purs
+++ b/src/Data/Foreign/Class.purs
@@ -4,11 +4,12 @@ import Prelude
 import Control.Monad.Except (mapExcept)
 import Data.Array ((..), zipWith, length)
 import Data.Bifunctor (lmap)
-import Data.Foreign (F, Foreign, ForeignError(ErrorAtIndex), readArray, readBoolean, readChar, readInt, readNumber, readString, toForeign, unsafeFromForeign)
+import Data.Foreign (F, Foreign, ForeignError(ErrorAtIndex), readArray, readBoolean, readChar, readInt, readNumber, readString, toForeign)
 import Data.Foreign.NullOrUndefined (NullOrUndefined(..), readNullOrUndefined, undefined)
 import Data.Maybe (maybe)
 import Data.StrMap as StrMap
 import Data.Traversable (sequence)
+import Data.Foreign.Internal (readStrMap)
 
 -- | The `Decode` class is used to generate decoding functions
 -- | of the form `Foreign -> F a` using `generics-rep` deriving.
@@ -55,7 +56,7 @@ instance arrayDecode :: Decode a => Decode (Array a) where
     readElement i value = mapExcept (lmap (map (ErrorAtIndex i))) (decode value)
 
 instance strMapDecode :: (Decode v) => Decode (StrMap.StrMap v) where
-  decode = sequence <<< StrMap.mapWithKey (\_ -> decode) <<< unsafeFromForeign
+  decode = sequence <<< StrMap.mapWithKey (\_ -> decode) <=< readStrMap
 
 -- | The `Encode` class is used to generate encoding functions
 -- | of the form `a -> Foreign` using `generics-rep` deriving.

--- a/src/Data/Foreign/Internal.purs
+++ b/src/Data/Foreign/Internal.purs
@@ -2,12 +2,12 @@ module Data.Foreign.Internal where
 
 import Prelude
 
-import Data.Foreign (F, Foreign, ForeignError(..), fail, isArray, tagOf, unsafeFromForeign)
+import Data.Foreign (F, Foreign, ForeignError(..), fail, tagOf, unsafeFromForeign)
 import Data.StrMap (StrMap)
 
 -- | Test whether a foreign value is a dictionary
 isStrMap :: Foreign -> Boolean
-isStrMap v = tagOf v == "Object" && not (isArray v || tagOf v == "Date")
+isStrMap v = tagOf v == "Object"
 
 -- | Attempt to coerce a foreign value to a StrMap
 readStrMap :: Foreign -> F (StrMap Foreign)

--- a/src/Data/Foreign/Internal.purs
+++ b/src/Data/Foreign/Internal.purs
@@ -1,0 +1,16 @@
+module Data.Foreign.Internal where
+
+import Prelude
+
+import Data.Foreign (F, Foreign, ForeignError(..), fail, isArray, tagOf, unsafeFromForeign)
+import Data.StrMap (StrMap)
+
+-- | Test whether a foreign value is a dictionary
+isStrMap :: Foreign -> Boolean
+isStrMap v = tagOf v == "Object" && not (isArray v || tagOf v == "Date")
+
+-- | Attempt to coerce a foreign value to a StrMap
+readStrMap :: Foreign -> F (StrMap Foreign)
+readStrMap value
+  | isStrMap value = pure $ unsafeFromForeign value
+  | otherwise = fail $ TypeMismatch "StrMap" (tagOf value)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -14,6 +14,7 @@ import Data.Foreign.JSON (parseJSON)
 import Data.Foreign.NullOrUndefined (NullOrUndefined(..))
 import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(..))
+import Data.StrMap as StrMap
 import Data.String (toLower, toUpper)
 import Data.Tuple (Tuple(..))
 import Global.Unsafe (unsafeStringify)
@@ -96,4 +97,5 @@ main = do
   testRoundTrip (Apple)
   testRoundTrip (makeTree 0)
   testRoundTrip (makeTree 5)
+  testRoundTrip (StrMap.fromFoldable [Tuple "one" 1, Tuple "two" 2])
   testUnaryConstructorLiteral


### PR DESCRIPTION
This is broken in that it uses `unsafeFromForeign`, so this is basically some way of asking if it's OK to add a `readStrMap` to `purescript-foreign` .