### PR TITLE
Decode and encode instances for JSDate.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
     "purescript-maps": "^3.3.1",
     "purescript-nullable": "^3.0.0",
     "purescript-proxy": "^2.1.0",
-    "purescript-symbols": "^3.0.0"
+    "purescript-symbols": "^3.0.0",
+    "purescript-js-date": "^5.1.0"
   },
   "devDependencies": {
     "purescript-assert": "^3.0.0"

--- a/src/Data/Foreign/Class.purs
+++ b/src/Data/Foreign/Class.purs
@@ -6,6 +6,7 @@ import Data.Array ((..), zipWith, length)
 import Data.Bifunctor (lmap)
 import Data.Foreign (F, Foreign, ForeignError(ErrorAtIndex), readArray, readBoolean, readChar, readInt, readNumber, readString, toForeign)
 import Data.Foreign.NullOrUndefined (NullOrUndefined(..), readNullOrUndefined, undefined)
+import Data.JSDate (JSDate, readDate)
 import Data.Maybe (maybe)
 import Data.StrMap as StrMap
 import Data.Traversable (sequence)
@@ -58,6 +59,9 @@ instance arrayDecode :: Decode a => Decode (Array a) where
 instance strMapDecode :: (Decode v) => Decode (StrMap.StrMap v) where
   decode = sequence <<< StrMap.mapWithKey (\_ -> decode) <=< readStrMap
 
+instance jsDateDecode :: Decode JSDate where
+  decode = readDate
+
 -- | The `Encode` class is used to generate encoding functions
 -- | of the form `a -> Foreign` using `generics-rep` deriving.
 -- |
@@ -103,5 +107,5 @@ instance decodeNullOrUndefined :: Decode a => Decode (NullOrUndefined a) where
 instance encodeNullOrUndefined :: Encode a => Encode (NullOrUndefined a) where
   encode (NullOrUndefined a) = maybe undefined encode a
 
-instance strMapEncode :: Encode v => Encode (StrMap.StrMap v) where 
+instance strMapEncode :: Encode v => Encode (StrMap.StrMap v) where
   encode = toForeign <<< StrMap.mapWithKey (\_ -> encode)

--- a/src/Data/Foreign/Class.purs
+++ b/src/Data/Foreign/Class.purs
@@ -109,3 +109,6 @@ instance encodeNullOrUndefined :: Encode a => Encode (NullOrUndefined a) where
 
 instance strMapEncode :: Encode v => Encode (StrMap.StrMap v) where
   encode = toForeign <<< StrMap.mapWithKey (\_ -> encode)
+
+instance jsDateEncode :: Encode JSDate where
+  encode = toForeign

--- a/src/Data/Foreign/JSON.js
+++ b/src/Data/Foreign/JSON.js
@@ -1,5 +1,15 @@
 "use strict";
 
+var dateFormat = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/;
+
+function jsDateReviver(key, value) {
+  if (typeof value === "string" && dateFormat.test(value)) {
+      return new Date(value);
+  }
+
+  return value;
+}
+
 exports.parseJSONImpl = function (str) {
-  return JSON.parse(str);
+  return JSON.parse(str, jsDateReviver);
 };

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -7,7 +7,7 @@ import Control.Monad.Eff.Console (CONSOLE, log)
 import Control.Monad.Except (runExcept)
 import Data.Bifunctor (bimap)
 import Data.Either (Either(..))
-import Data.Foreign.Class (class Decode, class Encode, decode, encode)
+import Data.Foreign.Class (class Decode, class Encode)
 import Data.Foreign.Generic (decodeJSON, defaultOptions, encodeJSON, genericDecodeJSON, genericEncodeJSON)
 import Data.Foreign.Generic.Class (class GenericDecode, class GenericEncode)
 import Data.Foreign.Generic.EnumEncoding (class GenericDecodeEnum, class GenericEncodeEnum, GenericEnumOptions, genericDecodeEnum, genericEncodeEnum)
@@ -116,9 +116,9 @@ testJSDateRoundTrip
          | eff
          ) Unit
 testJSDateRoundTrip date = do
-  log $ toString date
-  let encodedDate = encode date
-  case runExcept (decode encodedDate) of
+  let jsonDate = encodeJSON date
+  log jsonDate
+  case runExcept (decodeJSON jsonDate) of
     Right decodedDate -> assert (toString date == toString decodedDate)
     Left err -> throw (show err)
 
@@ -136,7 +136,7 @@ main = do
   testRoundTrip (StrMap.fromFoldable [Tuple "one" 1, Tuple "two" 2])
   testJSDateRoundTrip (jsdate
     { year: 2000.0, month: 2.0, day: 15.0
-    , hour: 20.0, minute: 30.0, second: 40.0, millisecond: 120.0 })
+    , hour: 20.0, minute: 30.0, second: 40.0, millisecond: 1234.0 })
   testUnaryConstructorLiteral
   let opts = defaultOptions { fieldTransform = toUpper }
   testGenericRoundTrip opts (RecordTest { foo: 1, bar: "test", baz: 'a' })

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -7,14 +7,15 @@ import Control.Monad.Eff.Console (CONSOLE, log)
 import Control.Monad.Except (runExcept)
 import Data.Bifunctor (bimap)
 import Data.Either (Either(..))
-import Data.Foreign.Class (class Encode, class Decode)
+import Data.Foreign.Class (class Decode, class Encode, decode, encode)
 import Data.Foreign.Generic (decodeJSON, defaultOptions, encodeJSON, genericDecodeJSON, genericEncodeJSON)
-import Data.Foreign.Generic.Class (class GenericDecode, class GenericEncode, encodeFields)
+import Data.Foreign.Generic.Class (class GenericDecode, class GenericEncode)
 import Data.Foreign.Generic.EnumEncoding (class GenericDecodeEnum, class GenericEncodeEnum, GenericEnumOptions, genericDecodeEnum, genericEncodeEnum)
-import Data.Foreign.Generic.Types (Options, SumEncoding(..))
+import Data.Foreign.Generic.Types (Options)
 import Data.Foreign.JSON (parseJSON)
 import Data.Foreign.NullOrUndefined (NullOrUndefined(..))
 import Data.Generic.Rep (class Generic)
+import Data.JSDate (JSDate, jsdate, toString)
 import Data.Maybe (Maybe(..))
 import Data.StrMap as StrMap
 import Data.String (toLower, toUpper)
@@ -107,6 +108,20 @@ testUnaryConstructorLiteral = do
       { constructorTagTransform: f
       }
 
+testJSDateRoundTrip
+  :: forall eff
+   . JSDate
+  -> Eff ( console :: CONSOLE
+         , assert :: ASSERT
+         | eff
+         ) Unit
+testJSDateRoundTrip date = do
+  log $ toString date
+  let encodedDate = encode date
+  case runExcept (decode encodedDate) of
+    Right decodedDate -> assert (toString date == toString decodedDate)
+    Left err -> throw (show err)
+
 main :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
 main = do
   testRoundTrip (RecordTest { foo: 1, bar: "test", baz: 'a' })
@@ -119,8 +134,9 @@ main = do
   testRoundTrip (makeTree 0)
   testRoundTrip (makeTree 5)
   testRoundTrip (StrMap.fromFoldable [Tuple "one" 1, Tuple "two" 2])
+  testJSDateRoundTrip (jsdate
+    { year: 2000.0, month: 2.0, day: 15.0
+    , hour: 20.0, minute: 30.0, second: 40.0, millisecond: 120.0 })
   testUnaryConstructorLiteral
   let opts = defaultOptions { fieldTransform = toUpper }
   testGenericRoundTrip opts (RecordTest { foo: 1, bar: "test", baz: 'a' })
-
-


### PR DESCRIPTION
Needed for querying date values using [purescript-mysql](https://pursuit.purescript.org/packages/purescript-mysql/0.1.3/docs/MySQL.Connection#v:query_).

Moved from `purescript-js-date` as suggested [here](https://github.com/purescript-contrib/purescript-js-date/pull/16#issuecomment-329262995).