### PR TITLE
add more instances, get rid of unNullOrUndefined, add null :: Foreign

### DIFF
--- a/src/Data/Foreign/NullOrUndefined.js
+++ b/src/Data/Foreign/NullOrUndefined.js
@@ -1,1 +1,2 @@
 exports['undefined'] = undefined;
+exports['null'] = null;

--- a/src/Data/Foreign/NullOrUndefined.purs
+++ b/src/Data/Foreign/NullOrUndefined.purs
@@ -16,13 +16,14 @@ newtype NullOrUndefined a = NullOrUndefined (Maybe a)
 derive instance newtypeNullOrUndefined :: Newtype (NullOrUndefined a) _
 derive instance eqNullOrUndefined :: Eq a => Eq (NullOrUndefined a)
 derive instance ordNullOrUndefined :: Ord a => Ord (NullOrUndefined a)
+derive newtype instance functorNullOrUndefined :: Functor NullOrUndefined
+derive newtype instance applyNullOrUndefined :: Apply NullOrUndefined
+derive newtype instance applicativeNullOrUndefined :: Applicative NullOrUndefined
+derive newtype instance bindNullOrUndefined :: Bind NullOrUndefined
+instance monadNullOrUndefined :: Monad NullOrUndefined
 
 instance showNullOrUndefined :: (Show a) => Show (NullOrUndefined a) where
   show x = "(NullOrUndefined " <> show (unwrap x) <> ")"
-
--- | Unwrap a `NullOrUndefined` value
-unNullOrUndefined :: forall a. NullOrUndefined a -> Maybe a
-unNullOrUndefined (NullOrUndefined m) = m
 
 -- | Read a `NullOrUndefined` value
 readNullOrUndefined :: forall a. (Foreign -> F a) -> Foreign -> F (NullOrUndefined a)
@@ -30,3 +31,4 @@ readNullOrUndefined _ value | isNull value || isUndefined value = pure (NullOrUn
 readNullOrUndefined f value = NullOrUndefined <<< Just <$> f value
 
 foreign import undefined :: Foreign
+foreign import null :: Foreign


### PR DESCRIPTION
since it has a `Newtype` instance, I thought `unNullOrUndefined` was redundant, but it is a breaking change.