### PR TITLE
Add unwrapSingleRecordArguments option for Aeson compatibility

### DIFF
--- a/src/Data/Foreign/Generic.purs
+++ b/src/Data/Foreign/Generic.purs
@@ -35,6 +35,7 @@ defaultOptions =
         }
   , unwrapSingleConstructors: false
   , unwrapSingleArguments: true
+  , unwrapSingleRecordArguments: false
   , fieldTransform: id
   }
 

--- a/src/Data/Foreign/Generic/Types.purs
+++ b/src/Data/Foreign/Generic/Types.purs
@@ -4,6 +4,7 @@ type Options =
   { sumEncoding :: SumEncoding
   , unwrapSingleConstructors :: Boolean
   , unwrapSingleArguments :: Boolean
+  , unwrapSingleRecordArguments :: Boolean
   , fieldTransform :: String -> String
   }
 

--- a/src/Data/Foreign/Generic/Types.purs
+++ b/src/Data/Foreign/Generic/Types.purs
@@ -1,5 +1,75 @@
 module Data.Foreign.Generic.Types where
 
+-- | Encoding options.
+-- | 
+-- | ### `unwrapSingleConstructors`
+-- | 
+-- | If true, data types with only one constructor will be encoded
+-- | without the constructor tag.
+-- | 
+-- | Example:
+-- | 
+-- | ```purescript
+-- | data SC = SC Int Int
+-- | -- encoding (SC 1 2)
+-- | ```
+-- | 
+-- | Without `unwrapSingleConstructors`:
+-- | 
+-- | `{ "tag": "SC, "contents": [1, 2] }`
+-- | 
+-- | With `unwrapSingleConstructors`:
+-- | 
+-- | `[1, 2]`
+-- | 
+-- | ### `unwrapSingleArguments`
+-- | 
+-- | In the general case, constructor arguments are encoded as an array.
+-- | 
+-- | If this option is enabled, for constructors with only one argument the argument
+-- | will not be wrapped in a single-element array.
+-- | 
+-- | Example:
+-- | 
+-- | ```purescript
+-- | data D = C1 Int | C2 Int
+-- | -- encoding (C2 1)
+-- | ```
+-- | 
+-- | Without `unwrapSingleArguments`:
+-- | 
+-- | `{ "tag": "C2", "contents": [1] }`
+-- | 
+-- | With `unwrapSingleArguments`:
+-- | 
+-- | `{ "tag": "C2", "contents": 1 }`
+-- | 
+-- | ### `unwrapSingleRecordArguments`
+-- | 
+-- | If this option is enabled, constructors where the only argument is a record
+-- | will be encoded without wrapping the record in a `contents` property;
+-- | instead, the record fields will be directly attached to the main object.
+-- |
+-- | This is the encoding used by `aeson` `genericToJSON`.
+-- | 
+-- | Example:
+-- | 
+-- | ```purescript
+-- | data D = C1 { x :: Int, y :: Int } | C2 { x :: Int }
+-- | -- encoding (C1 { x: 1, y: 2 })
+-- | ```
+-- | 
+-- | Without `unwrapSingleRecordArguments`:
+-- | 
+-- | `{ "tag": "C1", "contents": { "x": 1, "y": 2 } }`
+-- | 
+-- | With `unwrapSingleRecordArguments`:
+-- | 
+-- | `{ "tag": "C1", "x": 1, "y": 2 }`
+-- | 
+-- | ### `fieldTransform`
+-- | 
+-- | A transformation function on record field names.
 type Options =
   { sumEncoding :: SumEncoding
   , unwrapSingleConstructors :: Boolean

--- a/test/Types.purs
+++ b/test/Types.purs
@@ -11,7 +11,7 @@ import Data.Foreign.Generic.Types (Options, SumEncoding(..))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Eq (genericEq)
 import Data.Generic.Rep.Show (genericShow)
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe)
 import Data.Tuple (Tuple(..))
 
 newtype TupleArray a b = TupleArray (Tuple a b)
@@ -126,3 +126,10 @@ instance dFruit :: Decode Fruit where
   decode = genericDecodeEnum defaultGenericEnumOptions
 instance eFruit :: Encode Fruit where
   encode = genericEncodeEnum defaultGenericEnumOptions
+
+data Mixed =
+    Record { field1 :: String }
+  | Other Int
+
+derive instance eqMixed :: Eq Mixed
+derive instance geMixed :: Generic Mixed _


### PR DESCRIPTION
The option is documented in the Types module. Also added documentation for the
existing options.

Should help solve #5.