### PR TITLE
support for purescript 0.12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
     "purescript-globals": "^4.0.0",
     "purescript-nullable": "7240560f96576e93a82a51758e6985748a519a82",
     "purescript-proxy": "^3.0.0",
+    "purescript-record": "^1.0.0",
     "purescript-symbols": "78f37303898a36b562e1b0d8a35d4d58cfe039ef",
     "purescript-ordered-collections": "^1.0.0"
   },

--- a/bower.json
+++ b/bower.json
@@ -15,16 +15,17 @@
     "url": "git://github.com/paf31/purescript-foreign-generic.git"
   },
   "dependencies": {
+    "purescript-prelude": "^4.0.1",
     "purescript-console": "^4.1.0",
     "purescript-effect": "^2.0.0",
     "purescript-exceptions": "^4.0.0",
     "purescript-foreign": "^5.0.0",
     "purescript-generics-rep": "^6.0.0",
     "purescript-globals": "^4.0.0",
-    "purescript-maps": "fb6d610613e720ea6b05b8d8a27ae5cf210cea08",
     "purescript-nullable": "7240560f96576e93a82a51758e6985748a519a82",
     "purescript-proxy": "^3.0.0",
-    "purescript-symbols": "78f37303898a36b562e1b0d8a35d4d58cfe039ef"
+    "purescript-symbols": "78f37303898a36b562e1b0d8a35d4d58cfe039ef",
+    "purescript-ordered-collections": "^1.0.0"
   },
   "devDependencies": {
     "purescript-assert": "^4.0.0"

--- a/bower.json
+++ b/bower.json
@@ -15,18 +15,18 @@
     "url": "git://github.com/paf31/purescript-foreign-generic.git"
   },
   "dependencies": {
-    "purescript-console": "^3.0.0",
-    "purescript-eff": "^3.1.0",
-    "purescript-exceptions": "^3.0.0",
-    "purescript-foreign": "^4.0.1",
-    "purescript-generics-rep": "^5.1.0",
-    "purescript-globals": "^3.0.0",
-    "purescript-maps": "^3.3.1",
-    "purescript-nullable": "^3.0.0",
-    "purescript-proxy": "^2.1.0",
-    "purescript-symbols": "^3.0.0"
+    "purescript-console": "^4.1.0",
+    "purescript-effect": "^2.0.0",
+    "purescript-exceptions": "^4.0.0",
+    "purescript-foreign": "^5.0.0",
+    "purescript-generics-rep": "^6.0.0",
+    "purescript-globals": "^4.0.0",
+    "purescript-maps": "fb6d610613e720ea6b05b8d8a27ae5cf210cea08",
+    "purescript-nullable": "7240560f96576e93a82a51758e6985748a519a82",
+    "purescript-proxy": "^3.0.0",
+    "purescript-symbols": "78f37303898a36b562e1b0d8a35d4d58cfe039ef"
   },
   "devDependencies": {
-    "purescript-assert": "^3.0.0"
+    "purescript-assert": "^4.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,6 @@
     "purescript-nullable": "7240560f96576e93a82a51758e6985748a519a82",
     "purescript-proxy": "^3.0.0",
     "purescript-record": "^1.0.0",
-    "purescript-symbols": "78f37303898a36b562e1b0d8a35d4d58cfe039ef",
     "purescript-ordered-collections": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "pulp": "^11.0.0",
-    "purescript": "^0.11.5",
+    "pulp": "^12.2.0",
+    "purescript": "^0.12.0",
     "purescript-psa": "^0.5.1",
     "rimraf": "^2.6.1"
   }

--- a/src/Data/Foreign/Class.purs
+++ b/src/Data/Foreign/Class.purs
@@ -5,12 +5,12 @@ import Control.Monad.Except (except, mapExcept)
 import Data.Array ((..), zipWith, length)
 import Data.Bifunctor (lmap)
 import Data.Either (Either(..))
-import Data.Foreign (F, Foreign, ForeignError(..), readArray, readBoolean, readChar, readInt, readNumber, readString, toForeign)
-import Data.Foreign.NullOrUndefined (readNullOrUndefined, undefined)
-import Data.Maybe (Maybe, maybe)
-import Data.StrMap as StrMap
-import Data.Traversable (sequence)
 import Data.Foreign.Internal (readStrMap)
+import Data.Foreign.NullOrUndefined (readNullOrUndefined, undefined)
+import Data.Map as Map
+import Data.Maybe (Maybe, maybe)
+import Data.Traversable (sequence)
+import Foreign (F, Foreign, ForeignError(..), readArray, readBoolean, readChar, readInt, readNumber, readString, unsafeToForeign)
 
 -- | The `Decode` class is used to generate decoding functions
 -- | of the form `Foreign -> F a` using `generics-rep` deriving.
@@ -65,8 +65,8 @@ instance arrayDecode :: Decode a => Decode (Array a) where
 instance maybeDecode :: Decode a => Decode (Maybe a) where
   decode = readNullOrUndefined decode
 
-instance strMapDecode :: (Decode v) => Decode (StrMap.StrMap v) where
-  decode = sequence <<< StrMap.mapWithKey (\_ -> decode) <=< readStrMap
+instance strMapDecode :: (Decode v) => Decode (Map.Map String v) where
+  decode = sequence <<< map decode <=< readStrMap
 
 -- | The `Encode` class is used to generate encoding functions
 -- | of the form `a -> Foreign` using `generics-rep` deriving.
@@ -90,31 +90,31 @@ instance voidEncode :: Encode Void where
   encode = absurd
 
 instance unitEncode :: Encode Unit where
-  encode _ = toForeign {}
+  encode _ = unsafeToForeign {}
 
 instance foreignEncode :: Encode Foreign where
-  encode = id
+  encode = identity
 
 instance stringEncode :: Encode String where
-  encode = toForeign
+  encode = unsafeToForeign
 
 instance charEncode :: Encode Char where
-  encode = toForeign
+  encode = unsafeToForeign
 
 instance booleanEncode :: Encode Boolean where
-  encode = toForeign
+  encode = unsafeToForeign
 
 instance numberEncode :: Encode Number where
-  encode = toForeign
+  encode = unsafeToForeign
 
 instance intEncode :: Encode Int where
-  encode = toForeign
+  encode = unsafeToForeign
 
 instance arrayEncode :: Encode a => Encode (Array a) where
-  encode = toForeign <<< map encode
+  encode = unsafeToForeign <<< map encode
 
 instance maybeEncode :: Encode a => Encode (Maybe a) where
   encode = maybe undefined encode
 
-instance strMapEncode :: Encode v => Encode (StrMap.StrMap v) where
-  encode = toForeign <<< StrMap.mapWithKey (\_ -> encode)
+instance strMapEncode :: Encode v => Encode (Map.Map String v) where
+  encode = unsafeToForeign <<< map encode

--- a/src/Data/Foreign/Generic.purs
+++ b/src/Data/Foreign/Generic.purs
@@ -10,7 +10,7 @@ module Data.Foreign.Generic
 
 import Prelude
 
-import Data.Foreign (F, Foreign)
+import Foreign (F, Foreign)
 import Data.Foreign.Class (class Decode, class Encode, decode, encode)
 import Data.Foreign.Generic.Class (class GenericDecode, class GenericEncode, decodeOpts, encodeOpts)
 import Data.Foreign.Generic.Types (Options, SumEncoding(..))
@@ -31,11 +31,11 @@ defaultOptions =
       TaggedObject
         { tagFieldName: "tag"
         , contentsFieldName: "contents"
-        , constructorTagTransform: id
+        , constructorTagTransform: identity
         }
   , unwrapSingleConstructors: false
   , unwrapSingleArguments: true
-  , fieldTransform: id
+  , fieldTransform: identity
   }
 
 -- | Read a value which has a `Generic` type.

--- a/src/Data/Foreign/Generic/Class.purs
+++ b/src/Data/Foreign/Generic/Class.purs
@@ -45,13 +45,6 @@ class GenericEncodeArgs a where
 class GenericEncodeRowList (rl :: RowList) (row :: #Type) | rl -> row where
   encodeRecord :: forall g . g rl -> Options -> Record row -> M.Map String Foreign
 
-
-class GenericDecodeFields a where
-  decodeFields :: Options -> Foreign -> F a
-
-class GenericEncodeFields a where
-  encodeFields :: Options -> a -> M.Map String Foreign
-
 class GenericCountArgs a where
   countArgs :: Proxy a -> Either a Int
 
@@ -239,16 +232,6 @@ instance genericEncodeRowListcons
       namep = SProxy :: SProxy name
       value = get namep rec
       tailp = RLProxy :: RLProxy tail
-
-instance genericDecodeFieldsProduct
-  :: (GenericDecodeFields a, GenericDecodeFields b)
-  => GenericDecodeFields (Product a b) where
-  decodeFields opts x = Product <$> decodeFields opts x <*> decodeFields opts x
-
-instance genericEncodeFieldsProduct
-  :: (GenericEncodeFields a, GenericEncodeFields b)
-  => GenericEncodeFields (Product a b) where
-  encodeFields opts (Product a b) = encodeFields opts a `M.union` encodeFields opts b
 
 instance genericCountArgsNoArguments :: GenericCountArgs NoArguments where
   countArgs _ = Left NoArguments

--- a/src/Data/Foreign/Generic/Class.purs
+++ b/src/Data/Foreign/Generic/Class.purs
@@ -203,7 +203,7 @@ instance genericDecodeRowListCons
   decodeRecord _ opts x = do
     let fieldName = opts.fieldTransform $ reflectSymbol namep
     -- If `name` field doesn't exist, then `y` will be `undefined`.
-    fieldValue <- index x name >>= mapExcept (lmap (map (ErrorAtProperty fieldName))) <<< decode
+    fieldValue <- index x fieldName >>= mapExcept (lmap (map (ErrorAtProperty fieldName))) <<< decode
     rest <- decodeRecord tailp opts x
     let
       first :: Builder (Record from') (Record to)

--- a/src/Data/Foreign/Generic/Enum.purs
+++ b/src/Data/Foreign/Generic/Enum.purs
@@ -79,7 +79,12 @@ instance ctorNoArgsGenericDecodeEnum
     where
       ctorName = constructorTagTransform $ reflectSymbol (SProxy :: SProxy name)
 
-instance ctorArgumentGenericDecodeEnum
+instance ctorRecGenericDecodeEnum
+  :: Fail (Text "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments.")
+  => GenericDecodeEnum (Constructor name (Argument (Record a))) where
+  decodeEnum _ _ = unsafeCrashWith "unreachable decodeEnum was reached."
+
+else instance ctorArgumentGenericDecodeEnum
   :: Fail (Text "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments.")
   => GenericDecodeEnum (Constructor name (Argument a)) where
   decodeEnum _ _ = unsafeCrashWith "unreachable decodeEnum was reached."
@@ -89,13 +94,7 @@ instance ctorProductGenericDecodeEnum
   => GenericDecodeEnum (Constructor name (Product a b)) where
   decodeEnum _ _ = unsafeCrashWith "unreachable decodeEnum was reached."
 
--- TODO: replace with RowList
 
-{- instance ctorRecGenericDecodeEnum
-  :: Fail "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments."
-  => GenericDecodeEnum (Constructor name (Rec a)) where
-  decodeEnum _ _ = unsafeCrashWith "unreachable decodeEnum was reached."
- -}
 instance sumGenericEncodeEnum
   :: (GenericEncodeEnum a, GenericEncodeEnum b)
   => GenericEncodeEnum (Sum a b) where
@@ -109,7 +108,12 @@ instance ctorNoArgsGenericEncodeEnum
     where
       ctorName = constructorTagTransform $ reflectSymbol (SProxy :: SProxy name)
 
-instance ctorArgumentGenericEncodeEnum
+instance ctorRecGenericEncodeEnum
+  :: Fail (Text "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments.")
+  => GenericEncodeEnum (Constructor name (Argument (Record a))) where
+  encodeEnum _ _ = unsafeCrashWith "unreachable encodeEnum was reached."
+
+else instance ctorArgumentGenericEncodeEnum
   :: Fail (Text "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments.")
   => GenericEncodeEnum (Constructor name (Argument a)) where
   encodeEnum _ _ = unsafeCrashWith "unreachable encodeEnum was reached."
@@ -118,11 +122,3 @@ instance ctorProductGenericEncodeEnum
   :: Fail (Text "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments.")
   => GenericEncodeEnum (Constructor name (Product a b)) where
   encodeEnum _ _ = unsafeCrashWith "unreachable encodeEnum was reached."
-
--- TODO: replace with RowList
-
-{- instance ctorRecGenericEncodeEnum
-  :: Fail "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments."
-  => GenericEncodeEnum (Constructor name (Rec a)) where
-  encodeEnum _ _ = unsafeCrashWith "unreachable encodeEnum was reached."
- -}

--- a/src/Data/Foreign/Generic/Enum.purs
+++ b/src/Data/Foreign/Generic/Enum.purs
@@ -3,10 +3,11 @@ module Data.Foreign.Generic.EnumEncoding where
 import Prelude
 
 import Control.Alt ((<|>))
-import Data.Foreign (F, Foreign, ForeignError(..), fail, readString, toForeign)
-import Data.Generic.Rep (class Generic, Argument, Constructor(Constructor), NoArguments(NoArguments), Product, Rec, Sum(Inr, Inl), from, to)
+import Foreign (F, Foreign, ForeignError(..), fail, readString, unsafeToForeign)
+import Data.Generic.Rep (class Generic, Argument, Constructor(Constructor), NoArguments(NoArguments), Product, Sum(Inr, Inl), from, to)
 import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
 import Partial.Unsafe (unsafeCrashWith)
+import Prim.TypeError (class Fail, Text)
 
 type GenericEnumOptions =
   { constructorTagTransform :: String -> String
@@ -14,7 +15,7 @@ type GenericEnumOptions =
 
 defaultGenericEnumOptions :: GenericEnumOptions
 defaultGenericEnumOptions =
-  { constructorTagTransform: id
+  { constructorTagTransform: identity
   }
 
 -- | A generic function to be used with "Enums", or sum types with only no-argument constructors. This is used for decoding from strings to one of the constructors, combined with the `constructorTagTransform` property of `SumEncoding`.
@@ -79,20 +80,22 @@ instance ctorNoArgsGenericDecodeEnum
       ctorName = constructorTagTransform $ reflectSymbol (SProxy :: SProxy name)
 
 instance ctorArgumentGenericDecodeEnum
-  :: Fail "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments."
+  :: Fail (Text "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments.")
   => GenericDecodeEnum (Constructor name (Argument a)) where
   decodeEnum _ _ = unsafeCrashWith "unreachable decodeEnum was reached."
 
 instance ctorProductGenericDecodeEnum
-  :: Fail "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments."
+  :: Fail (Text "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments.")
   => GenericDecodeEnum (Constructor name (Product a b)) where
   decodeEnum _ _ = unsafeCrashWith "unreachable decodeEnum was reached."
 
-instance ctorRecGenericDecodeEnum
+-- TODO: replace with RowList
+
+{- instance ctorRecGenericDecodeEnum
   :: Fail "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments."
   => GenericDecodeEnum (Constructor name (Rec a)) where
   decodeEnum _ _ = unsafeCrashWith "unreachable decodeEnum was reached."
-
+ -}
 instance sumGenericEncodeEnum
   :: (GenericEncodeEnum a, GenericEncodeEnum b)
   => GenericEncodeEnum (Sum a b) where
@@ -102,21 +105,24 @@ instance sumGenericEncodeEnum
 instance ctorNoArgsGenericEncodeEnum
   :: IsSymbol name
   => GenericEncodeEnum (Constructor name NoArguments) where
-  encodeEnum {constructorTagTransform} _ = toForeign ctorName
+  encodeEnum {constructorTagTransform} _ = unsafeToForeign ctorName
     where
       ctorName = constructorTagTransform $ reflectSymbol (SProxy :: SProxy name)
 
 instance ctorArgumentGenericEncodeEnum
-  :: Fail "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments."
+  :: Fail (Text "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments.")
   => GenericEncodeEnum (Constructor name (Argument a)) where
   encodeEnum _ _ = unsafeCrashWith "unreachable encodeEnum was reached."
 
 instance ctorProductGenericEncodeEnum
-  :: Fail "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments."
+  :: Fail (Text "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments.")
   => GenericEncodeEnum (Constructor name (Product a b)) where
   encodeEnum _ _ = unsafeCrashWith "unreachable encodeEnum was reached."
 
-instance ctorRecGenericEncodeEnum
+-- TODO: replace with RowList
+
+{- instance ctorRecGenericEncodeEnum
   :: Fail "genericEncode/DecodeEnum cannot be used on types that are not sums of constructors with no arguments."
   => GenericEncodeEnum (Constructor name (Rec a)) where
   encodeEnum _ _ = unsafeCrashWith "unreachable encodeEnum was reached."
+ -}

--- a/src/Data/Foreign/Internal.purs
+++ b/src/Data/Foreign/Internal.purs
@@ -2,8 +2,10 @@ module Data.Foreign.Internal where
 
 import Prelude
 
-import Data.Foreign (F, Foreign, ForeignError(..), fail, tagOf, unsafeFromForeign)
-import Data.StrMap (StrMap)
+import Foreign (F, Foreign, ForeignError(..), fail, tagOf, unsafeFromForeign)
+import Data.Map (Map)
+
+type StrMap a = Map String a
 
 -- | Test whether a foreign value is a dictionary
 isStrMap :: Foreign -> Boolean

--- a/src/Data/Foreign/JSON.js
+++ b/src/Data/Foreign/JSON.js
@@ -3,3 +3,9 @@
 exports.parseJSONImpl = function (str) {
   return JSON.parse(str);
 };
+
+exports.addToObjImpl = function (key, value, obj) {
+  var clone = Object.assign({}, obj);
+  clone[key] = value;
+  return clone;
+}

--- a/src/Data/Foreign/JSON.purs
+++ b/src/Data/Foreign/JSON.purs
@@ -4,25 +4,26 @@ module Data.Foreign.JSON
   ) where
 
 import Prelude
-import Control.Monad.Eff (runPure)
-import Control.Monad.Eff.Exception (EXCEPTION, message, try)
-import Control.Monad.Eff.Uncurried (EffFn1, runEffFn1)
+
 import Control.Monad.Except (ExceptT(..))
 import Data.Bifunctor (lmap)
-import Data.Foreign (Foreign, ForeignError(..), F)
 import Data.Identity (Identity(..))
+import Effect.Exception (message, try)
+import Effect.Uncurried (EffectFn1, runEffectFn1)
+import Effect.Unsafe (unsafePerformEffect)
+import Foreign (Foreign, ForeignError(..), F)
 
-foreign import parseJSONImpl :: forall eff. EffFn1 (exception :: EXCEPTION | eff) String Foreign
+foreign import parseJSONImpl :: EffectFn1 String Foreign
 
 -- | Parse a JSON string as `Foreign` data
 parseJSON :: String -> F Foreign
 parseJSON =
   ExceptT
   <<< Identity
-  <<< lmap (pure <<< JSONError <<< message)
-  <<< runPure
-  <<< try
-  <<< runEffFn1 parseJSONImpl
+  <<< lmap (pure <<< ForeignError <<< message)
+  <<< unsafePerformEffect
+  <<< try 
+  <<< runEffectFn1 parseJSONImpl
 
 decodeJSONWith :: forall a. (Foreign -> F a) -> String -> F a
 decodeJSONWith f = f <=< parseJSON

--- a/src/Data/Foreign/JSON.purs
+++ b/src/Data/Foreign/JSON.purs
@@ -1,12 +1,14 @@
 module Data.Foreign.JSON
   ( parseJSON
   , decodeJSONWith
+  , addToObj
   ) where
 
 import Prelude
 
 import Control.Monad.Except (ExceptT(..))
 import Data.Bifunctor (lmap)
+import Data.Function.Uncurried (Fn3, runFn3)
 import Data.Identity (Identity(..))
 import Effect.Exception (message, try)
 import Effect.Uncurried (EffectFn1, runEffectFn1)
@@ -14,6 +16,11 @@ import Effect.Unsafe (unsafePerformEffect)
 import Foreign (Foreign, ForeignError(..), F)
 
 foreign import parseJSONImpl :: EffectFn1 String Foreign
+
+foreign import addToObjImpl :: Fn3 String Foreign Foreign Foreign
+
+addToObj :: String -> Foreign -> Foreign -> Foreign
+addToObj = runFn3 addToObjImpl
 
 -- | Parse a JSON string as `Foreign` data
 parseJSON :: String -> F Foreign

--- a/src/Data/Foreign/NullOrUndefined.purs
+++ b/src/Data/Foreign/NullOrUndefined.purs
@@ -3,7 +3,7 @@ module Data.Foreign.NullOrUndefined where
 import Prelude
 
 import Data.Maybe (Maybe(..))
-import Data.Foreign (F, Foreign, isUndefined, isNull)
+import Foreign (F, Foreign, isUndefined, isNull)
 
 -- | Read a value which may be null or undefined.
 readNullOrUndefined :: forall a. (Foreign -> F a) -> Foreign -> F (Maybe a)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -7,9 +7,9 @@ import Data.Bifunctor (bimap)
 import Data.Either (Either(..))
 import Data.Foreign.Class (class Encode, class Decode)
 import Data.Foreign.Generic (decodeJSON, defaultOptions, encodeJSON, genericDecodeJSON, genericEncodeJSON)
-import Data.Foreign.Generic.Class (class GenericDecode, class GenericEncode, encodeFields)
+import Data.Foreign.Generic.Class (class GenericDecode, class GenericEncode)
 import Data.Foreign.Generic.EnumEncoding (class GenericDecodeEnum, class GenericEncodeEnum, GenericEnumOptions, genericDecodeEnum, genericEncodeEnum)
-import Data.Foreign.Generic.Types (Options, SumEncoding(..))
+import Data.Foreign.Generic.Types (Options)
 import Data.Foreign.JSON (parseJSON)
 import Data.Generic.Rep (class Generic)
 import Data.Map as Map
@@ -19,8 +19,6 @@ import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Effect.Console (log)
 import Global.Unsafe (unsafeStringify)
-import Partial (crashWith)
-import Partial.Unsafe (unsafePartial)
 import Test.Assert (assert, assert')
 import Test.Types (Fruit(..), IntList(..), RecordTest(..), Tree(..), TupleArray(..), UndefinedTest(..))
 
@@ -107,5 +105,4 @@ main = do
   testRoundTrip (Map.fromFoldable [Tuple "one" 1, Tuple "two" 2])
   testUnaryConstructorLiteral
   let opts = defaultOptions { fieldTransform = toUpper }
-  unsafePartial (crashWith "Implement me with RowList")
-  -- TODO testGenericRoundTrip opts (RecordTest { foo: 1, bar: "test", baz: 'a' })
+  testGenericRoundTrip opts (RecordTest { foo: 1, bar: "test", baz: 'a' })

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -61,10 +61,14 @@ testGenericRoundTrip
   -> Effect Unit
 testGenericRoundTrip opts x = do
   let json = genericEncodeJSON opts x
-  log json
+  log $ "encoded: " <> json
   case runExcept (genericDecodeJSON opts json) of
-    Right y -> assert (x == y)
-    Left err -> throw (show err)
+    Right y -> do
+      assert (x == y)
+      log "OK"
+    Left err -> 
+      throw (show err)
+  log ""
 
 testOption
   :: ∀ a rep
@@ -130,9 +134,9 @@ main = do
   log "testing tree 5 items .."
   testRoundTrip (makeTree 5)
 
-  log "testing map.."
-  testRoundTrip (Map.fromFoldable [Tuple "one" 1, Tuple "two" 2])
-
   log "testing Record with fieldTransform .."
   let opts = defaultOptions { fieldTransform = toUpper }
   testGenericRoundTrip opts (RecordTest { foo: 1, bar: "test", baz: 'a' })
+
+  log "testing map.."
+  testRoundTrip (Map.fromFoldable [Tuple "one" 1, Tuple "two" 2])

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -12,7 +12,6 @@ import Data.Foreign.Generic.EnumEncoding (class GenericDecodeEnum, class Generic
 import Data.Foreign.Generic.Types (Options)
 import Data.Foreign.JSON (parseJSON)
 import Data.Generic.Rep (class Generic)
-import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.String (toLower, toUpper)
 import Data.Tuple (Tuple(..))

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -137,6 +137,3 @@ main = do
   log "testing Record with fieldTransform .."
   let opts = defaultOptions { fieldTransform = toUpper }
   testGenericRoundTrip opts (RecordTest { foo: 1, bar: "test", baz: 'a' })
-
-  log "testing map.."
-  testRoundTrip (Map.fromFoldable [Tuple "one" 1, Tuple "two" 2])

--- a/test/Types.purs
+++ b/test/Types.purs
@@ -55,7 +55,7 @@ instance eqRecordTest :: Eq RecordTest where
   eq x y = genericEq x y
 
 instance decodeRecordTest :: Decode RecordTest where
-  decode x = unsafePartial (crashWith "Implement me with RowList") -- TODO: genericDecode (defaultOptions { unwrapSingleConstructors = true }) x
+  decode x = genericDecode (defaultOptions { unwrapSingleConstructors = true }) x
 
 instance encodeRecordTest :: Encode RecordTest where
   encode x = unsafePartial (crashWith "Implement me with RowList") -- TODO: genericEncode (defaultOptions { unwrapSingleConstructors = true }) x

--- a/test/Types.purs
+++ b/test/Types.purs
@@ -7,15 +7,12 @@ import Data.Foreign.Class (class Encode, class Decode, encode, decode)
 import Data.Foreign.Generic (defaultOptions, genericDecode, genericEncode)
 import Data.Foreign.Generic.EnumEncoding (defaultGenericEnumOptions, genericDecodeEnum, genericEncodeEnum)
 import Data.Foreign.Generic.Types (Options, SumEncoding(..))
-import Data.Foreign.NullOrUndefined (undefined)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Eq (genericEq)
 import Data.Generic.Rep.Show (genericShow)
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe)
 import Data.Tuple (Tuple(..))
 import Foreign (ForeignError(ForeignError), fail, readArray, unsafeToForeign)
-import Partial (crash, crashWith)
-import Partial.Unsafe (unsafePartial)
 
 newtype TupleArray a b = TupleArray (Tuple a b)
 
@@ -113,9 +110,9 @@ derive instance eqUT :: Eq UndefinedTest
 derive instance geUT :: Generic UndefinedTest _
 
 instance dUT :: Decode UndefinedTest where
-  decode = unsafePartial (crashWith "Implement me with RowList") -- TODO: genericDecode $ defaultOptions
+  decode = genericDecode $ defaultOptions
 instance eUT :: Encode UndefinedTest where
-  encode = unsafePartial (crashWith "Implement me with RowList") -- TODO: genericEncode $ defaultOptions
+  encode = genericEncode $ defaultOptions
 
 data Fruit
   = Apple

--- a/test/Types.purs
+++ b/test/Types.purs
@@ -58,7 +58,7 @@ instance decodeRecordTest :: Decode RecordTest where
   decode x = genericDecode (defaultOptions { unwrapSingleConstructors = true }) x
 
 instance encodeRecordTest :: Encode RecordTest where
-  encode x = unsafePartial (crashWith "Implement me with RowList") -- TODO: genericEncode (defaultOptions { unwrapSingleConstructors = true }) x
+  encode x = genericEncode (defaultOptions { unwrapSingleConstructors = true }) x
 
 -- | An example of an ADT with nullary constructors
 data IntList = Nil | Cons Int IntList

--- a/test/Types.purs
+++ b/test/Types.purs
@@ -3,16 +3,19 @@ module Test.Types where
 import Prelude
 
 import Data.Bifunctor (class Bifunctor)
-import Data.Foreign (ForeignError(ForeignError), fail, readArray, toForeign)
 import Data.Foreign.Class (class Encode, class Decode, encode, decode)
 import Data.Foreign.Generic (defaultOptions, genericDecode, genericEncode)
 import Data.Foreign.Generic.EnumEncoding (defaultGenericEnumOptions, genericDecodeEnum, genericEncodeEnum)
 import Data.Foreign.Generic.Types (Options, SumEncoding(..))
+import Data.Foreign.NullOrUndefined (undefined)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Eq (genericEq)
 import Data.Generic.Rep.Show (genericShow)
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
+import Foreign (ForeignError(ForeignError), fail, readArray, unsafeToForeign)
+import Partial (crash, crashWith)
+import Partial.Unsafe (unsafePartial)
 
 newtype TupleArray a b = TupleArray (Tuple a b)
 
@@ -34,7 +37,7 @@ instance decodeTupleArray :: (Decode a, Decode b) => Decode (TupleArray a b) whe
       _ -> fail (ForeignError "Expected two array elements")
 
 instance encodeTupleArray :: (Encode a, Encode b) => Encode (TupleArray a b) where
-  encode (TupleArray (Tuple a b)) = toForeign [encode a, encode b]
+  encode (TupleArray (Tuple a b)) = unsafeToForeign [encode a, encode b]
 
 -- | An example record
 newtype RecordTest = RecordTest
@@ -52,10 +55,10 @@ instance eqRecordTest :: Eq RecordTest where
   eq x y = genericEq x y
 
 instance decodeRecordTest :: Decode RecordTest where
-  decode x = genericDecode (defaultOptions { unwrapSingleConstructors = true }) x
+  decode x = unsafePartial (crashWith "Implement me with RowList") -- TODO: genericDecode (defaultOptions { unwrapSingleConstructors = true }) x
 
 instance encodeRecordTest :: Encode RecordTest where
-  encode x = genericEncode (defaultOptions { unwrapSingleConstructors = true }) x
+  encode x = unsafePartial (crashWith "Implement me with RowList") -- TODO: genericEncode (defaultOptions { unwrapSingleConstructors = true }) x
 
 -- | An example of an ADT with nullary constructors
 data IntList = Nil | Cons Int IntList
@@ -110,9 +113,9 @@ derive instance eqUT :: Eq UndefinedTest
 derive instance geUT :: Generic UndefinedTest _
 
 instance dUT :: Decode UndefinedTest where
-  decode = genericDecode $ defaultOptions
+  decode = unsafePartial (crashWith "Implement me with RowList") -- TODO: genericDecode $ defaultOptions
 instance eUT :: Encode UndefinedTest where
-  encode = genericEncode $ defaultOptions
+  encode = unsafePartial (crashWith "Implement me with RowList") -- TODO: genericEncode $ defaultOptions
 
 data Fruit
   = Apple


### PR DESCRIPTION
ok, there are quite a few things going on:

- `Eff` -> `Effect`
- `Rec` and `Field` was removed from `generics-rep` so this one supports records via `RowList`
- `StrMap` was dropped (indeed the complete dependency is deprecated) - I use `Map` from `ordered-collections` for the representation while encoding/decoding but I dropped support for `Map`s itself
- `nullable` have not transitioned to purescript 0.12 per version yet - bower.json depends on the latest commit, so this should be changed
- I modified the *tests* a bit so that the output is better readable (I had a few bugs)

---

what's left to do:

- [ ] wait for `nullable`
- [ ] provide support for maps again(?)
- [ ] use a testframework?

---

I hope this helps you out - have fun