### PR TITLE
Encode Nothing as null rather than undefined

### DIFF
--- a/src/Foreign/Class.purs
+++ b/src/Foreign/Class.purs
@@ -10,7 +10,7 @@ import Data.Maybe (Maybe, maybe)
 import Data.Traversable (sequence)
 import Foreign (F, Foreign, ForeignError(..), readArray, readBoolean, readChar, readInt, readNumber, readString, unsafeToForeign)
 import Foreign.Internal (readObject)
-import Foreign.NullOrUndefined (readNullOrUndefined, undefined)
+import Foreign.NullOrUndefined (readNullOrUndefined, null)
 import Foreign.Object (Object)
 import Foreign.Object as Object
 
@@ -116,7 +116,7 @@ instance arrayEncode :: Encode a => Encode (Array a) where
   encode = unsafeToForeign <<< map encode
 
 instance maybeEncode :: Encode a => Encode (Maybe a) where
-  encode = maybe undefined encode
+  encode = maybe null encode
 
 instance objectEncode :: Encode v => Encode (Object v) where
   encode = unsafeToForeign <<< Object.mapWithKey (\_ -> encode)

--- a/src/Foreign/NullOrUndefined.js
+++ b/src/Foreign/NullOrUndefined.js
@@ -1,1 +1,3 @@
+exports['null'] = null;
+
 exports['undefined'] = undefined;

--- a/src/Foreign/NullOrUndefined.purs
+++ b/src/Foreign/NullOrUndefined.purs
@@ -11,3 +11,5 @@ readNullOrUndefined _ value | isNull value || isUndefined value = pure Nothing
 readNullOrUndefined f value = Just <$> f value
 
 foreign import undefined :: Foreign
+
+foreign import null :: Foreign


### PR DESCRIPTION
Previously, the Encode (Maybe a) instance was mapping Nothing to
undefined, which meant that Nothing fields in records would disappear
when stringifying:

    -- old behaviour
    newtype Foo = Foo { x :: Maybe Int }
    derive instance genericFoo :: Generic Foo _

    foo = Foo { x: Nothing }
    log (encodeJSON foo)
    -- {"tag":"Foo","contents":{}}

This commit changes the behaviour of the Encode (Maybe a) instance so
that Nothing is mapped to null rather than undefined. This means that
Nothing fields are present in the JSON, with a value of null:

    -- new behaviour
    log (encodeJSON foo)
    -- {"tag":"Foo","contents":{"x":null}}

Note that we remain lenient about decoding records with Maybe fields:
a field may be present and have a value of null, or it may be absent;
in both cases, the field is decoded as Nothing.

This change brings foreign-generic more into line with Aeson, as by
default Aeson will also encode Nothing fields as present with a value of
null (in fact, this is configurable in Aeson: there is a configuration
option `omitNothingFields` which, when turned on, means that
Nothing-valued fields will be omitted during JSON encoding.)

Maybe values which ended up inside arrays in the encoded JSON are
unaffected by this change; previously they were mapped to `null` anyway.

Maybe values at the top level of the encoded JSON, however, are
affected. In fact, encoding Maybe values at the top level could
previously lead to runtime errors:

    -- previously
    > encodeJSON (Nothing :: Maybe Int)
    ./purescript-foreign-generic/.psci_modules/node_modules/Data.Show/foreign.js:30
      var l = s.length;
                ^

    TypeError: Cannot read property 'length' of undefined

    -- now
    > encodeJSON (Nothing :: Maybe Int)
    "null"