### PR TITLE
 option to unwrap records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bower_components/
 output/
 .psc-package
 .psc-ide-port
+node_modules/
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "clean": "rimraf output && rimraf .pulp-cache",
     "build": "pulp build -- --censor-lib --strict",
+    "purs:ide": "purs ide server --log-level=debug 'bower_components/purescript-*/src/**/*.purs' 'src/**/*.purs' 'test/**/*.purs'",
     "test": "pulp test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "pulp test"
   },
   "devDependencies": {
+    "bower": "^1.8.4",
     "pulp": "^12.0.0",
     "purescript": "^0.12.0",
     "purescript-psa": "^0.5.0",

--- a/src/Foreign/Generic.purs
+++ b/src/Foreign/Generic.purs
@@ -1,5 +1,6 @@
 module Foreign.Generic
   ( defaultOptions
+  , aesonSumEncoding
   , genericDecode
   , genericEncode
   , decodeJSON
@@ -38,6 +39,15 @@ defaultOptions =
   , unwrapSingleArguments: true
   , fieldTransform: identity
   }
+
+-- | Aeson unwraps records, use this sum encoding with Aeson generated json
+aesonSumEncoding :: SumEncoding
+aesonSumEncoding = TaggedObject
+        { tagFieldName: "tag"
+        , contentsFieldName: "contents"
+        , constructorTagTransform: identity
+        , unwrapRecords: true
+        }
   
 -- | Read a value which has a `Generic` type.
 genericDecode

--- a/src/Foreign/Generic.purs
+++ b/src/Foreign/Generic.purs
@@ -32,6 +32,7 @@ defaultOptions =
         { tagFieldName: "tag"
         , contentsFieldName: "contents"
         , constructorTagTransform: identity
+        , unwrapRecords: false
         }
   , unwrapSingleConstructors: false
   , unwrapSingleArguments: true

--- a/src/Foreign/Generic/Types.purs
+++ b/src/Foreign/Generic/Types.purs
@@ -15,4 +15,5 @@ data SumEncoding
     { tagFieldName :: String
     , contentsFieldName :: String
     , constructorTagTransform :: String -> String
+    , unwrapRecords :: Boolean
     }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -22,7 +22,7 @@ import Foreign.JSON (parseJSON)
 import Foreign.Object as Object
 import Global.Unsafe (unsafeStringify)
 import Test.Assert (assert, assert')
-import Test.Types (Fruit(..), IntList(..), RecordTest(..), Tree(..), TupleArray(..), UndefinedTest(..))
+import Test.Types (Fruit(..), IntList(..), RecordTest(..), Tree(..), TupleArray(..), UndefinedTest(..), SumWithRecord(..))
 
 buildTree :: forall a. (a -> TupleArray a a) -> Int -> a -> Tree a
 buildTree _ 0 a = Leaf a
@@ -128,6 +128,10 @@ testNothingFromMissing =
 main :: Effect Unit
 main = do
   testRoundTrip (RecordTest { foo: 1, bar: "test", baz: 'a' })
+  testRoundTrip NoArgs
+  testRoundTrip (SomeArg "some argument")
+  testRoundTrip (ManyArgs "fst" "snd")
+  testRoundTrip (RecordArgs { foo: 1, bar: "test", baz: 'a' })
   testRoundTrip (Cons 1 (Cons 2 (Cons 3 Nil)))
   testRoundTrip (UndefinedTest {a: Just "test"})
   testRoundTrip (UndefinedTest {a: Nothing})

--- a/test/Types.purs
+++ b/test/Types.purs
@@ -57,6 +57,38 @@ instance decodeRecordTest :: Decode RecordTest where
 instance encodeRecordTest :: Encode RecordTest where
   encode x = genericEncode (defaultOptions { unwrapSingleConstructors = true }) x
 
+-- | A sum type with record args
+data SumWithRecord
+  = NoArgs
+  | SomeArg String
+  | ManyArgs String String
+  | RecordArgs
+    { foo :: Int
+    , bar :: String
+    , baz :: Char
+    }
+
+derive instance genericSumWithRecord :: Generic SumWithRecord _
+
+instance showSumWithRecord :: Show SumWithRecord where
+  show x = genericShow x
+
+instance eqSumWithRecord :: Eq SumWithRecord where
+  eq x y = genericEq x y
+
+unwrapRecordsEncoding :: SumEncoding
+unwrapRecordsEncoding = TaggedObject { tagFieldName: "tag"
+                                     , contentsFieldName: "contents"
+                                     , constructorTagTransform: identity
+                                     , unwrapRecords: true
+                                     }
+
+instance decodeSumWithRecord :: Decode SumWithRecord where
+  decode x = genericDecode (defaultOptions { unwrapSingleConstructors = true, sumEncoding = unwrapRecordsEncoding }) x
+
+instance encodeSumWithRecord :: Encode SumWithRecord where
+  encode x = genericEncode (defaultOptions { unwrapSingleConstructors = true, sumEncoding = unwrapRecordsEncoding }) x
+
 -- | An example of an ADT with nullary constructors
 data IntList = Nil | Cons Int IntList
 
@@ -76,6 +108,7 @@ intListOptions =
                                                , constructorTagTransform: \tag -> case tag of
                                                                                     "Cons" -> "cOnS"
                                                                                     _ -> ""
+                                               , unwrapRecords: false
                                                }
                  }
 


### PR DESCRIPTION
Aeson unwraps a record argument to a constructor into the JSON object see
 http://hackage.haskell.org/package/aeson-1.4.0.0/docs/Data-Aeson.html#t:SumEncoding

"If the constructor is a record the encoded record fields will be
unpacked into this object"

In this commit we add an option to TaggedObject to do this unwrapping
 but we leave the default behaviour as is