### PR TITLE
Add `Either` and `Maybe` de/encode instances

### DIFF
--- a/src/Foreign/Generic/Class.purs
+++ b/src/Foreign/Generic/Class.purs
@@ -212,8 +212,8 @@ instance maybeEncode :: Encode a => Encode (Maybe a) where
 
 instance eitherEncode :: (Encode a, Encode b) => Encode (Either a b) where
   encode = case _ of 
-    Left value -> unsafeToForeign $ Record.insert (SProxy:: SProxy "Left") (encode value) {}
-    Right value -> unsafeToForeign $ Record.insert (SProxy:: SProxy "Right") (encode value) {}
+    Left value -> unsafeToForeign $ {"Left": encode value }
+    Right value -> unsafeToForeign $ { "Right": encode value }
 
 instance tupleEncode :: (Encode a, Encode b) => Encode (Tuple a b) where
   encode (Tuple a b) = encode [encode a, encode b]


### PR DESCRIPTION
This PR adds `Encode` and `Decode` instances for `Either` and `Maybe` and `Set` #5 

The encodings are:

`Left 1 <=> {"Left": 1}`

`Tuple 1 2  <=> [1, 2]`

`fromFoldable [1, 2, 3]  <=> [1, 2, 3]`

Decoding `[1, 1, 2, 3]` as a Set will fail with an error, because of the duplicate element