### PR TITLE
Split LICENSE files

### DIFF
--- a/LICENSE_THIRDPARTY
+++ b/LICENSE_THIRDPARTY
@@ -1,6 +1,9 @@
-The MIT License (MIT)
+purescript-foreign-generic uses code taken from the purescript-foreign library,
+which is used under the terms of the MIT license, below:
 
-Copyright (c) 2017 Phil Freeman
+  The MIT License (MIT)
+
+  Copyright (c) 2014 PureScript
 
   Permission is hereby granted, free of charge, to any person obtaining a copy of
   this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
This PR splits the LICENSE file out into two files:
- LICENSE for the `foreign-generic` license
- LICENSE_THIRDPARTY for the notice of adaptation from `foreign`

`licensee` will now correctly detect the contents of the LICENSE file:

```
λ licensee detect LICENSE
License:        MIT
Matched files:  LICENSE
LICENSE:
  Content hash:  4c2c763d64bbc7ef2e58b0ec6d06d90cee9755c9
  Attribution:   Copyright (c) 2017 Phil Freeman
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       MIT
```

### Motivation

`foreign-generic` is currently in the PureScript [package set](https://github.com/purescript/package-sets) and will need to have this license issue addressed in order to remain in the package set after the move to the new PureScript registry.

See https://github.com/purescript/registry/issues/250 for more details.